### PR TITLE
Teensy 3 support

### DIFF
--- a/src/bitlash-api.c
+++ b/src/bitlash-api.c
@@ -58,7 +58,7 @@ void initBitlash(unsigned long baud) {
 	beginSerial(baud);
 #endif
 
-#if defined(ARM_BUILD)
+#if ((defined(ARM_BUILD)) && (ARM_BUILD!=2))
 	eeinit();
 #endif
 

--- a/src/bitlash-api.c
+++ b/src/bitlash-api.c
@@ -58,7 +58,7 @@ void initBitlash(unsigned long baud) {
 	beginSerial(baud);
 #endif
 
-#if ((defined(ARM_BUILD)) && (ARM_BUILD!=2))
+#if defined(ARM_BUILD)
 	eeinit();
 #endif
 

--- a/src/bitlash-functions.c
+++ b/src/bitlash-functions.c
@@ -89,32 +89,7 @@ numvar func_free(void) {
 #if defined(UNIX_BUILD)
 	return 1000L;
 #elif defined(ARM_BUILD)
-	numvar size = 0;
-	#if ARM_BUILD==1
-		// Arduino Due (96K)
-		// untested!!! reduce this to 32768 if arduino crashes on start
-		unsigned int bit = 65536; // Highest bit
-	#elif ARM_BUILD==2
-		// Teensy 3 (16K)
-		unsigned int bit = 4096; // Highest bit
-	#else
-		unsigned int bit = 4096; // Highest bit
-	#endif
-
-	while (bit>1)
-	{
-		cli();
-		byte *buf = (byte *) malloc(size+bit);
-		free(buf);
-		sei();
-		if (buf != NULL)
-		{
-			size=size+bit;
-		}
-		bit=bit>>1;
-	}
-	
-	return size;    
+	return 1000L;
 #else
 	numvar ret;
 	// from http://forum.pololu.com/viewtopic.php?f=10&t=989&view=unread#p4218

--- a/src/bitlash-functions.c
+++ b/src/bitlash-functions.c
@@ -86,10 +86,37 @@ numvar func_beep(void) { 		// unumvar pin, unumvar frequency, unumvar duration)
 #endif
 
 numvar func_free(void) {
-#if defined(UNIX_BUILD) || defined(ARM_BUILD)
+#if defined(UNIX_BUILD)
 	return 1000L;
+#elif defined(ARM_BUILD)
+	numvar size = 0;
+	#if ARM_BUILD==1
+		// Arduino Due (96K)
+		// untested!!! reduce this to 32768 if arduino crashes on start
+		unsigned int bit = 65536; // Highest bit
+	#elif ARM_BUILD==2
+		// Teensy 3 (16K)
+		unsigned int bit = 4096; // Highest bit
+	#else
+		unsigned int bit = 4096; // Highest bit
+	#endif
+
+	while (bit>1)
+	{
+		cli();
+		byte *buf = (byte *) malloc(size+bit);
+		free(buf);
+		sei();
+		if (buf != NULL)
+		{
+			size=size+bit;
+		}
+		bit=bit>>1;
+	}
+	
+	return size;    
 #else
-numvar ret;
+	numvar ret;
 	// from http://forum.pololu.com/viewtopic.php?f=10&t=989&view=unread#p4218
 	extern int __bss_end;
 	return ((int)&ret) - ((int)&__bss_end);

--- a/src/bitlash-interpreter.c
+++ b/src/bitlash-interpreter.c
@@ -69,6 +69,8 @@ void cmd_boot(void) {
 	void (*bootvec)(void) = 0; (*bootvec)(); 	// we jump through 0 instead
 }
 #elif defined(ARM_BUILD)
+
+#if ARM_BUILD==1
 // SAM3XA software restart
 void cmd_boot(void) {
 	// See SAM3X data sheet for reference information.  This is a software
@@ -78,6 +80,18 @@ void cmd_boot(void) {
 	REG_RSTC_CR = (RSTC_CR_PROCRST | RSTC_CR_PERRST | RSTC_CR_EXTRST | RSTC_CR_KEY(0xA5));
 	while(1);
 }
+#else
+void cmd_boot(void) {
+  #ifndef SCB_AIRCR_SYSRESETREQ_MASK
+    #define SCB_AIRCR_SYSRESETREQ_MASK ((unsigned int) 0x00000004)
+  #endif
+
+  cli();
+  delay(100);
+  SCB_AIRCR = 0x05FA0000 | SCB_AIRCR_SYSRESETREQ_MASK;
+  while(1);
+}
+#endif
 #else
 void cmd_boot(void) {oops('boot');}
 #endif

--- a/src/bitlash.h
+++ b/src/bitlash.h
@@ -40,6 +40,9 @@
 #define UNIX_BUILD 1
 #elif defined(__SAM3X8E__)
 #define ARM_BUILD 1
+#elif defined(__MK20DX128__) && defined (CORE_TEENSY)
+  // Teensy 3
+  #define ARM_BUILD 2
 #else
 #define AVR_BUILD 1
 #endif
@@ -49,7 +52,6 @@
 #include "avr/io.h"
 #include "avr/pgmspace.h"
 #include "avr/interrupt.h"
-#include <avr/wdt.h>
 #endif
 
 #if defined(AVR_BUILD) || defined(ARM_BUILD)
@@ -402,7 +404,7 @@ unsigned long millis(void);
 //
 //	ARM BUILD
 #if defined(ARM_BUILD)
-#define prog_char char
+ #define prog_char char
 #define prog_uchar byte
 #define PROGMEM
 #define pgm_read_byte(b) (*(char *)(b))
@@ -410,7 +412,12 @@ unsigned long millis(void);
 #define strncpy_P strncpy
 #define strcmp_P strcmp
 #define strlen_P strlen
-#define E2END 4096
+#if ARM_BUILD==1
+  #define E2END 4096
+#else
+  // Teensy 3
+  #define E2END 2048
+#endif
 
 #endif
 

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -29,22 +29,20 @@
 ***/
 #include "bitlash.h"
 
-#if defined(AVR_BUILD)
-
-#include "avr/eeprom.h"
-void eewrite(int addr, uint8_t value) { eeprom_write_byte((unsigned char *) addr, value); }
-uint8_t eeread(int addr) { return eeprom_read_byte((unsigned char *) addr); }
-
+#if (defined(AVR_BUILD)) || ( (defined(ARM_BUILD)) && (ARM_BUILD==2))
+	#include "avr/eeprom.h"
+	void eewrite(int addr, uint8_t value) { eeprom_write_byte((unsigned char *) addr, value); }
+	uint8_t eeread(int addr) { return eeprom_read_byte((unsigned char *) addr); }
 #elif defined(ARM_BUILD)
+	#if ARM_BUILD=!1
+		// A little fake eeprom for ARM testing
+		char virtual_eeprom[E2END];
 
-// A little fake eeprom for ARM testing
-char virtual_eeprom[E2END];
+		void eeinit(void) {
+			for (int i=0; i<E2END; i++) virtual_eeprom[i] = 255;
+		}
 
-void eeinit(void) {
-	for (int i=0; i<E2END; i++) virtual_eeprom[i] = 255;
-}
-
-void eewrite(int addr, uint8_t value) { virtual_eeprom[addr] = value; }
-uint8_t eeread(int addr) { return virtual_eeprom[addr]; }
-
+		void eewrite(int addr, uint8_t value) { virtual_eeprom[addr] = value; }
+		uint8_t eeread(int addr) { return virtual_eeprom[addr]; }
+	#endif
 #endif

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -30,11 +30,16 @@
 #include "bitlash.h"
 
 #if (defined(AVR_BUILD)) || ( (defined(ARM_BUILD)) && (ARM_BUILD==2))
+	// AVR or Teensy 3
 	#include "avr/eeprom.h"
 	void eewrite(int addr, uint8_t value) { eeprom_write_byte((unsigned char *) addr, value); }
 	uint8_t eeread(int addr) { return eeprom_read_byte((unsigned char *) addr); }
+	#if defined(ARM_BUILD)
+		// Initialize Teensy 3 eeprom
+		void eeinit(void) { eeprom_initialize(); }
+	#endif
 #elif defined(ARM_BUILD)
-	#if ARM_BUILD=!1
+	#if ARM_BUILD!=2
 		// A little fake eeprom for ARM testing
 		char virtual_eeprom[E2END];
 


### PR DESCRIPTION
I have added support for Teensy 3 ARM Boards with internal EEPROM. This is working fine

Function for free memory is now giving back something useful on ARM. I cannot test this on an Arduino ARM board. On Teensy a crash occours when initial bit value is >4096.  I am not 100% shure about correct function.
