### PR TITLE
Support for a Microchip 24xx32A EEPROM module attached to the I2C bus, like the DigiX has

### DIFF
--- a/src/bitlash.h
+++ b/src/bitlash.h
@@ -528,7 +528,8 @@ void eeputs(int);
 									// http://ww1.microchip.com/downloads/en/DeviceDoc/21713J.pdf
 									// Specifically, the DigiX has such a module onboard
 									// https://digistump.com/wiki/digix/tutorials/eeprom
-//#define EEPROM_ADDRESS 0x50		// default address for DigiX boards
+
+#define EEPROM_ADDRESS 0x50			// default EEPROM address for DigiX boards
 
 ////////////////////////
 //

--- a/src/bitlash.h
+++ b/src/bitlash.h
@@ -520,6 +520,15 @@ void eeputs(int);
 #define STARTDB 0
 #define FAIL ((int)-1)
 
+/////////////////////////////////////////////
+// External EEPROM (I2C)
+//
+//#define EEPROM_MICROCHIP_24XX32A	// Uncomment to enable EEPROM via I2C
+									// Supports a Microchip 24xx32A EEPROM module attached to the I2C bus
+									// http://ww1.microchip.com/downloads/en/DeviceDoc/21713J.pdf
+									// Specifically, the DigiX has such a module onboard
+									// https://digistump.com/wiki/digix/tutorials/eeprom
+//#define EEPROM_ADDRESS 0x50		// default address for DigiX boards
 
 ////////////////////////
 //
@@ -527,9 +536,13 @@ void eeputs(int);
 //
 // Use the predefined constant from the avr-gcc support file
 //
-#define ENDDB E2END
-#define ENDEEPROM E2END
-
+#if defined(EEPROM_MICROCHIP_24XX32A)
+	#define ENDDB 4095
+	#define ENDEEPROM 4095
+#else
+	#define ENDDB E2END
+	#define ENDEEPROM E2END
+#endif
 
 /////////////////////////////////////////////
 // bitlash-error.c

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -29,14 +29,8 @@
 ***/
 #include "bitlash.h"
 
-//#define EEPROM_MICROCHIP_24XX32A	// uncomment to enable EEPROM via I2C
-#define EEPROM_ADDRESS 0x50			// default address for DigiX boards
-
 #if defined(EEPROM_MICROCHIP_24XX32A)
-	// Supports a Microchip 24xx32A EEPROM module attached to the I2C bus
-	// http://ww1.microchip.com/downloads/en/DeviceDoc/21713J.pdf
-	// Specifically, the DigiX has such a module onboard
-	// https://digistump.com/wiki/digix/tutorials/eeprom
+
 	#include "Wire.h"
 
 	void eeinit(void) {


### PR DESCRIPTION
Hi there!

I would very much like to use Bitlash on my [DigiX](http://www.kickstarter.com/projects/digistump/digix-the-ultimate-arduino-compatible-board-with-w) so I added some basic EEPROM support for it. The DigiX comes with a Microchip 24LC32AT-I EEPROM module onboard, attached to the I2C bus on address 0x50. This is a nice addition since the AT91SAM3X8E doesn't come with this functionality.

Since I'm fairly new to writing Arduino libraries, I'm sure some things can be done in a better way. The most obvious thing is that EEPROM access is actually quite slow. This is due to the I2C bus but also because I went for a simple implementation of eeread() and eewrite(). Doing reads/writes in blocks instead of individually and/or keeping a copy in RAM would probably help.

Anyway, I'm awaiting your feadback and I hope we can get this change merged in master eventually ;-)

cheers,
Remco
