### PR TITLE
issue #21: remove offset from addresses in the peep command output

### DIFF
--- a/src/bitlash-eeprom.c
+++ b/src/bitlash-eeprom.c
@@ -249,7 +249,7 @@ void cmd_peep(void) {
 int i=0;
 
 	while (i <= ENDEEPROM) {
-		if (!(i&63)) {speol(); printHex(i+0xe000); spb(':'); }
+		if (!(i&63)) {speol(); printIntegerInBase(i, 16, 4, '0'); spb(':'); }
 		if (!(i&7)) spb(' ');
 		if (!(i&3)) spb(' ');		
 		byte c = eeread(i) & 0xff;


### PR DESCRIPTION
A constant offset of 0xe000 was added purely to assist in formatting the
addresses which can be replaced by reusing the printIntegerInBase function.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
