### PR TITLE
Added support for stop name

### DIFF
--- a/src/bitlash-interpreter.c
+++ b/src/bitlash-interpreter.c
@@ -322,7 +322,10 @@ numvar retval = 0;
 		}
 		else 
 #endif
-			stopTask(getnum());
+            if (sym == s_script_eeprom)
+                stopTaskByName(idbuf);
+            else
+                stopTask(getnum());
 	}
 
 	else if (sym == s_rm) {		// rm "sym" or rm *

--- a/src/bitlash-taskmgr.c
+++ b/src/bitlash-taskmgr.c
@@ -58,6 +58,20 @@ void initTaskList(void) {
 
 void stopTask(byte slot) { if (slot < NUMTASKS) tasklist[slot] = SLOT_FREE; }
 
+void stopTaskByName(char *taskName)
+{
+    int entryID = findKey(taskName);
+
+    if (entryID == -1)  // not found
+        return;
+
+    for (byte slot = 0; slot < NUMTASKS; slot++) 
+    {
+        if (tasklist[slot] == entryID)
+            stopTask(slot);
+    }
+}
+
 // add task to run list
 void startTask(int macroid, numvar snoozems) {
 byte slot;

--- a/src/bitlash.h
+++ b/src/bitlash.h
@@ -624,6 +624,7 @@ numvar func_printf_handler(byte, byte);
 //
 void initTaskList(void);
 void runBackgroundTasks(void);
+void stopTaskByName(char *taskName);
 void stopTask(byte);
 void startTask(int, numvar);
 void snooze(unumvar);


### PR DESCRIPTION
I've used bitlash for a few projects and as soon as you get just a little complicated or creative you end up with several background tasks running at different times (e.g. timeouts, etc.).  These tasks need to interact and it quickly becomes a challenge to manage them by slot number.  Instead, it would be great if you could kill them by name.

I modified the code so it now supports "stop [*|num|name]".

Example usage
```
run t1, 1000
run t2, 1000
run t3, 1000
run t2, 1500

ps
0: t1
1: t2
2: t3
3: t2

stop t2

ps
0: t1
2: t3

```